### PR TITLE
Update nxmp uninstall configuration in config.ini

### DIFF
--- a/Sources/NXVenom/switch/.packages/Software Installer/nxmp/config.ini
+++ b/Sources/NXVenom/switch/.packages/Software Installer/nxmp/config.ini
@@ -8,4 +8,4 @@ move /config/uberhand/downloads/app/ /switch/
 delete /config/uberhand/downloads
 
 [Uninstall]
-delete /switch/nxmp
+delete /switch/nxmp-deko3d


### PR DESCRIPTION
Change the uninstall configuration to delete /switch/nxmp-deko3d instead of /switch/nxmp.