### PR TITLE
Update hekate_ipl.ini boot name

### DIFF
--- a/Sources/NXVenom/bootloader/hekate_ipl.ini
+++ b/Sources/NXVenom/bootloader/hekate_ipl.ini
@@ -25,7 +25,7 @@ kip1=atmosphere/kips/loader.kip
 icon=bootloader/res/icon_semistock.bmp
 {}
 
-[OFW (Stock)]
+[Semi-Stock]
 emummc_force_disable=1
 fss0=atmosphere/package3
 cal0blank=0


### PR DESCRIPTION
- `OFW Stock` ➜ `Semi-Stock`
There is no real “OFW” option. True “full OFW” can only be achieved by rebooting to OFW. See line 26 in the official config: https://github.com/CTCaer/hekate/blob/master/res/hekate_ipl_template.ini