### PR TITLE
Feature: DBI with ultra nx shop

### DIFF
--- a/Sources/NXVenom/switch/.packages/Software Installer/DBI/config.ini
+++ b/Sources/NXVenom/switch/.packages/Software Installer/DBI/config.ini
@@ -18,6 +18,8 @@ set-ini-val /switch/DBI/dbi.config Filtering InheritFilter false
 set-ini-val /switch/DBI/dbi.locations Location_0 Name notUltraNX
 set-ini-val /switch/DBI/dbi.locations Location_0 Type ApacheHTTP
 set-ini-val /switch/DBI/dbi.locations Location_0 URL https://dbi.ultranx.ru/
+remove-ini-section /switch/DBI/dbi.locations Location_1
+remove-ini-section /switch/DBI/dbi.locations Location_2
 delete /config/uberhand/downloads
 
 ; [Install / Update - PT-BR]
@@ -41,6 +43,8 @@ set-ini-val /switch/DBI/dbi.config Filtering InheritFilter false
 set-ini-val /switch/DBI/dbi.locations Location_0 Name notUltraNX
 set-ini-val /switch/DBI/dbi.locations Location_0 Type ApacheHTTP
 set-ini-val /switch/DBI/dbi.locations Location_0 URL https://dbi.ultranx.ru/
+remove-ini-section /switch/DBI/dbi.locations Location_1
+remove-ini-section /switch/DBI/dbi.locations Location_2
 delete /config/uberhand/downloads
 
 ; [Install / Update - RU]
@@ -64,6 +68,8 @@ set-ini-val /switch/DBI/dbi.config Filtering InheritFilter false
 set-ini-val /switch/DBI/dbi.locations Location_0 Name notUltraNX
 set-ini-val /switch/DBI/dbi.locations Location_0 Type ApacheHTTP
 set-ini-val /switch/DBI/dbi.locations Location_0 URL https://dbi.ultranx.ru/
+remove-ini-section /switch/DBI/dbi.locations Location_1
+remove-ini-section /switch/DBI/dbi.locations Location_2
 delete /config/uberhand/downloads
 
 [Uninstall]

--- a/Sources/NXVenom/switch/.packages/Software Installer/DBI/config.ini
+++ b/Sources/NXVenom/switch/.packages/Software Installer/DBI/config.ini
@@ -14,6 +14,10 @@ delete /config/uberhand/downloads
 download https://github.com/CatcherITGF/NX-Venom/raw/main/Sources/Tools/Apps/DBI.en.zip /config/uberhand/downloads/
 unzip /config/uberhand/downloads/DBI.en.zip /config/uberhand/downloads/app/
 move /config/uberhand/downloads/app/ /switch/DBI/
+set-ini-val /switch/DBI/dbi.config Filtering InheritFilter false
+set-ini-val /switch/DBI/dbi.locations Location_0 Name notUltraNX
+set-ini-val /switch/DBI/dbi.locations Location_0 Type ApacheHTTP
+set-ini-val /switch/DBI/dbi.locations Location_0 URL https://dbi.ultranx.ru/
 delete /config/uberhand/downloads
 
 ; [Install / Update - PT-BR]
@@ -33,6 +37,10 @@ delete /config/uberhand/downloads
 download https://github.com/CatcherITGF/NX-Venom/raw/main/Sources/Tools/Apps/DBI.ptbr.zip /config/uberhand/downloads/
 unzip /config/uberhand/downloads/DBI.ptbr.zip /config/uberhand/downloads/app/
 move /config/uberhand/downloads/app/ /switch/DBI/
+set-ini-val /switch/DBI/dbi.config Filtering InheritFilter false
+set-ini-val /switch/DBI/dbi.locations Location_0 Name notUltraNX
+set-ini-val /switch/DBI/dbi.locations Location_0 Type ApacheHTTP
+set-ini-val /switch/DBI/dbi.locations Location_0 URL https://dbi.ultranx.ru/
 delete /config/uberhand/downloads
 
 ; [Install / Update - RU]
@@ -52,6 +60,10 @@ delete /config/uberhand/downloads
 download https://github.com/CatcherITGF/NX-Venom/raw/main/Sources/Tools/Apps/DBI.ru.zip /config/uberhand/downloads/
 unzip /config/uberhand/downloads/DBI.ru.zip /config/uberhand/downloads/app/
 move /config/uberhand/downloads/app/ /switch/DBI/
+set-ini-val /switch/DBI/dbi.config Filtering InheritFilter false
+set-ini-val /switch/DBI/dbi.locations Location_0 Name notUltraNX
+set-ini-val /switch/DBI/dbi.locations Location_0 Type ApacheHTTP
+set-ini-val /switch/DBI/dbi.locations Location_0 URL https://dbi.ultranx.ru/
 delete /config/uberhand/downloads
 
 [Uninstall]


### PR DESCRIPTION


Maybe we steal some games — we’re already using a piracy-enabled Switch anyway.

You have two options:
	1.	Use this prebuilt version: [DBI.RU.zip](https://github.com/Ultra-NX/Ultra-Resources/releases/download/Homebrews/DBI.RU.zip)
	2.	Or update Nx-Venom’s built-in DBI. It uses the same config file as Ultra-NX.