### PR TITLE
Feature: DBI with UltraNX eshop

### DIFF
--- a/Sources/NXVenom/switch/.packages/Software Installer/DBI/config.ini
+++ b/Sources/NXVenom/switch/.packages/Software Installer/DBI/config.ini
@@ -49,7 +49,7 @@ delete /config/uberhand/downloads
 [Install / Update - RU]
 catch_errors
 delete /config/uberhand/downloads
-download https://github.com/CatcherITGF/NX-Venom/raw/main/Sources/Tools/Apps/DBI.ru.zip /config/uberhand/downloads/
+download https://github.com/Ultra-NX/Ultra-Resources/releases/download/Homebrews/DBI.RU.zip /config/uberhand/downloads/
 unzip /config/uberhand/downloads/DBI.ru.zip /config/uberhand/downloads/app/
 move /config/uberhand/downloads/app/ /switch/DBI/
 delete /config/uberhand/downloads


### PR DESCRIPTION
Maybe we steal some games — we’re already using a piracy-enabled Switch anyway.

You have two options:
	1.	Use this prebuilt version: [DBI.RU.zip](https://github.com/Ultra-NX/Ultra-Resources/releases/download/Homebrews/DBI.RU.zip)
	2.	Or update Nx-Venom’s built-in DBI. It uses the same config file as Ultra-NX.